### PR TITLE
chore: add apecloud-mysql yaml

### DIFF
--- a/static/yamls/apecloud-mysql.yaml
+++ b/static/yamls/apecloud-mysql.yaml
@@ -1,0 +1,18 @@
+- name: mysql
+  componentDefRef: mysql
+  replicas: 1
+  resources: # Change the values of resources.
+    requests:
+      memory: "1Gi"
+      cpu: "1000m"
+    limits:
+      memory: "2Gi"
+      cpu: "2000m"
+  volumeClaimTemplates:
+  - name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi


### PR DESCRIPTION

Add apecloud-mysql.yaml for kbcli running follow command:
```shell
kbcli cluster create mycluster --cluster-definition apecloud-mysql --set-file https://kubeblocks.io/yamls/apecloud-mysql.yaml
```